### PR TITLE
feature: introduce top level `generate` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ pip install @elevenlabs/api
 We support two main models: the newest `eleven_multilingual_v2`, a single foundational model supporting 29 languages including English, Chinese, Spanish, Hindi, Portuguese, French, German, Japanese, Arabic, Korean, Indonesian, Italian, Dutch, Turkish, Polish, Swedish, Filipino, Malay, Russian, Romanian, Ukrainian, Greek, Czech, Danish, Finnish, Bulgarian, Croatian, Slovak, and Tamil; and `eleven_monolingual_v1`, a low-latency model specifically trained for English speech.
 
 ```ts
-import { ElevenLabsClient, play } from "@elevenlabs/api";
+import { ElevenLabsClient, play } from "elevenlabs";
 
 const elevenlabs = new ElevenLabsClient({
-  apiKey: process.env.ELEVENLABS_API_KEY // Defaults to this
+  apiKey: "YOUR_API_KEY" // Defaults to process.env.ELEVENLABS_API_KEY
 })
 
-const audio = elevenlabs.textToSpeech.convert('21m00Tcm4TlvDq8ikWAM', {
+const audio = await elevenlabs.generate({
+  voice: "Rachel",
   text: "Hello! 你好! Hola! नमस्ते! Bonjour! こんにちは! مرحبا! 안녕하세요! Ciao! Cześć! Привіт! வணக்கம்!",
   model_id: "eleven_multilingual_v2"
 });
@@ -52,13 +53,12 @@ await play(audio);
 
 List all your available voices with `voices()`.
 ```ts
-import { ElevenLabsClient } from "@elevenlabs/api";
+import { ElevenLabsClient } from "elevenlabs";
 
 const elevenlabs = new ElevenLabsClient({
-  apiKey: process.env.ELEVENLABS_API_KEY // Defaults to this
+  apiKey: "YOUR_API_KEY" // Defaults to process.env.ELEVENLABS_API_KEY
 })
-
-const voices = elevenlabs.voices.getAll();
+const voices = await elevenlabs.voices.getAll();
 ```
 
 <details> <summary> Show output </summary> </details>
@@ -104,9 +104,28 @@ const voices = elevenlabs.voices.getAll();
 Stream audio in real-time, as it's being generated.
 
 ```ts
+import { ElevenLabsClient, stream } from "elevenlabs";
+
+const audioStream = await elevenlabs.generate({
+  stream: true,
+  voice: "Bella",
+  text: "This is a... streaming voice",
+  model_id: "eleven_multilingual_v2"
+});
+
+stream(audioStream)
+```
+
+## HTTP Client
+The SDK also exposes an HTTP client that you can use to query our 
+various endpoints directly. 
+
+```ts
 import { ElevenLabsClient, stream } from "@elevenlabs/api";
 
-const audioStream = elevenlabs.textToSpeech.convert('21m00Tcm4TlvDq8ikWAM', {
+const models = await eleven.models.getAll();
+
+const audioStream = await elevenlabs.textToSpeech.convert('21m00Tcm4TlvDq8ikWAM', {
   text: "This is a... streaming voice!!",
   model_id: "eleven_multilingual_v2"
 });

--- a/src/wrapper/ElevenLabsClient.ts
+++ b/src/wrapper/ElevenLabsClient.ts
@@ -2,6 +2,7 @@ import { ElevenLabsClient as FernClient } from "../Client";
 import * as ElevenLabs from "../api";
 import * as core from "../core";
 import * as errors from "../errors";
+import * as stream from "stream";
 
 export declare namespace ElevenLabsClient {
     interface Options {
@@ -10,6 +11,13 @@ export declare namespace ElevenLabsClient {
          * variable ELEVENLABS_API_KEY.
          */
         apiKey?: core.Supplier<string>;
+    }
+
+    interface GeneratAudioBulk extends ElevenLabs.BodyTextToSpeechV1TextToSpeechVoiceIdPost {}
+
+    interface GenerateAudioStream extends ElevenLabs.BodyTextToSpeechV1TextToSpeechVoiceIdStreamPost {
+        /* Specify stream: true if you would like to get the audio in chunks */
+        stream: true;
     }
 }
 
@@ -25,4 +33,54 @@ export class ElevenLabsClient extends FernClient {
             xiApiKey: apiKey,
         });
     }
+
+    /**
+     * Generates audio for a voice.
+     *
+     * @example Generate the entire audio
+     * import { play } from "elevenlabs";
+     *
+     * const audio = eleven.generate({
+     *   voiceId: "George" // defaults to Bella
+     * })
+     * await play(audio);
+     *
+     * @example
+     * import { stream } from "elevenlabs"
+     *
+     * const audioStream = eleven.generate({
+     *   stream: true,
+     *   voice: "Bella"
+     * })
+     * await stream(audioStream);
+     */
+    async generate(
+        request: (ElevenLabsClient.GeneratAudioBulk | ElevenLabsClient.GenerateAudioStream) & { voice?: string },
+        requestOptions: FernClient.RequestOptions = {}
+    ): Promise<stream.Readable> {
+        const voiceIdOrName = request.voice ?? "Bella";
+        const voiceId = isVoiceId(voiceIdOrName)
+            ? voiceIdOrName
+            : (await this.voices.getAll()).voices.filter((voice) => voice.name === voiceIdOrName)[0]?.voice_id;
+        if (voiceId == null) {
+            throw new errors.ElevenLabsError({
+                message: `${voiceIdOrName} is not a valid voice name`,
+            });
+        }
+        if (isGenerateAudioStream(request)) {
+            return await this.textToSpeech.convert(voiceId, request, requestOptions);
+        } else {
+            return await this.textToSpeech.convert(voiceId, request, requestOptions);
+        }
+    }
+}
+
+function isGenerateAudioStream(
+    value: ElevenLabsClient.GeneratAudioBulk | ElevenLabsClient.GenerateAudioStream
+): value is ElevenLabsClient.GenerateAudioStream {
+    return (value as ElevenLabsClient.GenerateAudioStream).stream != null;
+}
+
+function isVoiceId(val: string): boolean {
+    return /^[a-zA-Z0-9]{20}$/.test(val);
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -31,4 +31,16 @@ describe("eleven labs", () => {
         });
         stream(audioStream);
     });
+
+    it.skip("generate", async () => {
+        const eleven = new ElevenLabsClient({
+            apiKey: "197464a32e60dfb6982e479cbbd49748",
+        });
+        const audio = await eleven.generate({
+            voice: "Rachel",
+            text: "Hello! 你好! Hola! नमस्ते! Bonjour! こんにちは! مرحبا! 안녕하세요! Ciao! Cześć! Привіт! வணக்கம்!",
+            model_id: "eleven_multilingual_v2",
+        });
+        await play(audio);
+    });
 });


### PR DESCRIPTION
The SDK now has a top level `generate` method, similar to the Python SDK that delgates to `client.textToSpeech.convert(..)`