### PR TITLE
(fix): export play and stream methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * as ElevenLabs from "./api";
-export { ElevenLabsClient } from "./wrapper/ElevenLabsClient";
+export * from "./wrapper";
 export { ElevenLabsEnvironment } from "./environments";
 export { ElevenLabsError, ElevenLabsTimeoutError } from "./errors";


### PR DESCRIPTION
In this update, the `index.ts` now exports everything from the wrapper directory such as methods `play` and `stream`. 