### PR TITLE
docs: add the elevenlabs-js requires packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ await play(audio);
 
 </details>
 
+⚠️ elevenlabs-js requires [MPV](https://mpv.io/) and [ffmpeg](https://ffmpeg.org/).
+
 ## 🗣️ Voices
 
 List all your available voices with `voices()`.


### PR DESCRIPTION
Hi Team,

I added information to let the user know, the `elevenlabs-js` needs to be installed the `MPV` and `ffmpeg`.