### PR TITLE
Pass `environment` through the wrapper constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elevenlabs",
-    "version": "0.17.0",
+    "version": "0.17.1",
     "private": false,
     "repository": "https://github.com/elevenlabs/elevenlabs-js",
     "license": "MIT",

--- a/src/wrapper/ElevenLabsClient.ts
+++ b/src/wrapper/ElevenLabsClient.ts
@@ -5,7 +5,7 @@ import * as errors from "../errors";
 import * as stream from "stream";
 
 export declare namespace ElevenLabsClient {
-    interface Options {
+    interface Options extends FernClient.Options {
         /**
          * Your ElevenLabs API Key. Defaults to the environment
          * variable ELEVENLABS_API_KEY.
@@ -29,9 +29,8 @@ export class ElevenLabsClient extends FernClient {
                 message: "Please pass in your ElevenLabs API Key or export ELEVENLABS_API_KEY in your environment.",
             });
         }
-        super({
-            apiKey,
-        });
+        options.apiKey = apiKey;
+        super(options);
     }
 
     /**


### PR DESCRIPTION
Before:

```
$ npm run build
$ node
> const pkg = require("./dist");
undefined
> new pkg.ElevenLabsClient({apiKey: "a", environment: pkg.ElevenLabsEnvironment.ProductionUs})
ElevenLabsClient { _options: { apiKey: 'a' } }
```

After:

```
$ npm run build
$ node
> const pkg = require("./dist");
undefined
> new pkg.ElevenLabsClient({apiKey: "a", environment: pkg.ElevenLabsEnvironment.ProductionUs})
ElevenLabsClient {
  _options: { apiKey: 'a', environment: 'https://api.us.elevenlabs.io' }
}
```