### PR TITLE
Remove runtime check for `play` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elevenlabs",
-    "version": "1.50.2",
+    "version": "1.50.3",
     "private": false,
     "repository": "https://github.com/elevenlabs/elevenlabs-js",
     "license": "MIT",

--- a/src/wrapper/play.ts
+++ b/src/wrapper/play.ts
@@ -1,7 +1,6 @@
 import commandExists from "command-exists";
 import * as stream from "stream";
 import { ElevenLabsError } from "../errors/ElevenLabsError";
-import { RUNTIME } from "../core/runtime/runtime";
 import execa from "execa";
 
 export async function play(audio: stream.Readable): Promise<void> {

--- a/src/wrapper/play.ts
+++ b/src/wrapper/play.ts
@@ -5,11 +5,6 @@ import { RUNTIME } from "../core/runtime/runtime";
 import execa from "execa";
 
 export async function play(audio: stream.Readable): Promise<void> {
-    if (RUNTIME.type !== "node") {
-        throw new ElevenLabsError({
-            message: `This function is only supported in node environments. ${RUNTIME.type} is not supported`,
-        });
-    }
     if (!commandExists("ffplay")) {
         throw new ElevenLabsError({
             message: `ffplay from ffmpeg not found, necessary to play audio. 


### PR DESCRIPTION
Calling `ffplay` works in Bun 1.1.45 and Deno 2.1.7, there doesn't seem to be a need to restrict its usage to Node runtimes.

Fixes https://github.com/elevenlabs/elevenlabs-js/issues/87