### PR TITLE
fix: return web readable streams only

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -13,3 +13,4 @@ src/index.ts
 
 # Return Web Readable Stream
 src/core/fetcher/getResponseBody.ts
+tests/unit/fetcher/getResponseBody.test.ts

--- a/.fernignore
+++ b/.fernignore
@@ -10,3 +10,6 @@ src/wrapper
 src/index.ts
 
 .github/workflows
+
+# Return Web Readable Stream
+src/core/fetcher/getResponseBody.ts

--- a/src/core/fetcher/getResponseBody.ts
+++ b/src/core/fetcher/getResponseBody.ts
@@ -1,5 +1,3 @@
-import { chooseStreamWrapper } from "./stream-wrappers/chooseStreamWrapper";
-
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     if (response.body != null && responseType === "blob") {
         return await response.blob();
@@ -8,7 +6,7 @@ export async function getResponseBody(response: Response, responseType?: string)
     } else if (response.body != null && responseType === "sse") {
         return response.body;
     } else if (response.body != null && responseType === "streaming") {
-        return chooseStreamWrapper(response.body);
+        return response.body;
     } else if (response.body != null && responseType === "text") {
         return await response.text();
     } else {

--- a/tests/unit/fetcher/getResponseBody.test.ts
+++ b/tests/unit/fetcher/getResponseBody.test.ts
@@ -1,6 +1,5 @@
-import { RUNTIME } from "../../../src/core/runtime";
 import { getResponseBody } from "../../../src/core/fetcher/getResponseBody";
-import { chooseStreamWrapper } from "../../../src/core/fetcher/stream-wrappers/chooseStreamWrapper";
+import { RUNTIME } from "../../../src/core/runtime";
 
 describe("Test getResponseBody", () => {
     it("should handle blob response type", async () => {
@@ -26,7 +25,7 @@ describe("Test getResponseBody", () => {
             const mockResponse = new Response(mockStream);
             const result = await getResponseBody(mockResponse, "streaming");
             // need to reinstantiate string as a result of locked state in Readable Stream after registration with Response
-            expect(JSON.stringify(result)).toBe(JSON.stringify(await chooseStreamWrapper(new ReadableStream())));
+            expect(JSON.stringify(result)).toBe(JSON.stringify(new ReadableStream()));
         }
     });
 


### PR DESCRIPTION
This PR modifies the Fern generated code to only return web readable streams. This was done through `.fernignore` and will be upstreamed to the generator. 