### PR TITLE
Fix /speech-to-text with additional_formats

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -9,4 +9,7 @@ jest.config.js
 src/wrapper
 src/index.ts
 
+# Temporary patch for additional_formats serialization format.
+src/api/resources/speechToText/client/Client.ts
+
 .github/workflows

--- a/src/api/resources/speechToText/client/Client.ts
+++ b/src/api/resources/speechToText/client/Client.ts
@@ -83,9 +83,7 @@ export class SpeechToText {
         }
 
         if (request.additional_formats != null) {
-            for (const _item of request.additional_formats) {
-                _request.append("additional_formats", toJson(_item));
-            }
+            _request.append("additional_formats", toJson(request.additional_formats));
         }
 
         const _maybeEncodedRequest = await _request.getRequest();


### PR DESCRIPTION
This updates the `/speech-to-text` endpoint so that we correctly serialize the `additonal_formats` parameter as a JSON list rather than separate `multipart/form-data` parts (i.e. in the explode format).

Note that this is a temporary patch, so a `.fernignore` entry is included. A future generator update will remove the need for this.