### PR TITLE
Fix doc content returned void

### DIFF
--- a/src/api/resources/conversationalAi/client/Client.ts
+++ b/src/api/resources/conversationalAi/client/Client.ts
@@ -2523,6 +2523,7 @@ export class ConversationalAi {
             },
             contentType: "application/json",
             requestType: "json",
+            responseType: "text",
             timeoutMs: requestOptions?.timeoutInSeconds != null ? requestOptions.timeoutInSeconds * 1000 : 60000,
             maxRetries: requestOptions?.maxRetries,
             abortSignal: requestOptions?.abortSignal,

--- a/src/api/resources/conversationalAi/client/Client.ts
+++ b/src/api/resources/conversationalAi/client/Client.ts
@@ -2528,7 +2528,7 @@ export class ConversationalAi {
             abortSignal: requestOptions?.abortSignal,
         });
         if (_response.ok) {
-            return;
+            return _response.body;
         }
 
         if (_response.error.reason === "status-code") {


### PR DESCRIPTION
This would also change the type specification in `Client.d.ts` to not be void i think. Or maybe it hast to be specified in Fern.