### PR TITLE
fix: Use serialization layer in SpeechToText client

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -10,7 +10,7 @@ src/wrapper
 src/index.ts
 
 # Temporary patch for additional_formats serialization format.
-src/api/resources/speechToText/client/Client.ts
+# src/api/resources/speechToText/client/Client.ts
 
 .github/workflows
 

--- a/.fernignore
+++ b/.fernignore
@@ -10,7 +10,7 @@ src/wrapper
 src/index.ts
 
 # Temporary patch for additional_formats serialization format.
-# src/api/resources/speechToText/client/Client.ts
+src/api/resources/speechToText/client/Client.ts
 
 .github/workflows
 


### PR DESCRIPTION
The `SpeechToText` client is .fernignored due to a manual customization, so when the SDK moved to using the serialization layer, this client did not receive the serialization changes.
We have updated the client with the serialization changes, and reapplied the manual customization.

Fixes #203