### PR TITLE
Next.js + web support prototype

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "private": false,
     "repository": "github:elevenlabs/elevenlabs-js",
     "license": "MIT",
-    "main": "./index.js",
-    "types": "./index.d.ts",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
     "scripts": {
         "format": "prettier . --write --ignore-unknown",
         "build": "tsc",

--- a/src/stubs/child_process.ts
+++ b/src/stubs/child_process.ts
@@ -1,0 +1,71 @@
+// Minimal stub for child_process to allow bundlers/non-Node environments
+
+export type ChildProcess = {
+    stdin: NodeJS.WritableStream;
+    stdout: NodeJS.ReadableStream;
+    stderr: NodeJS.ReadableStream;
+    kill: (signal?: string | number) => boolean;
+    on: (event: string, listener: (...args: any[]) => void) => void;
+};
+
+function createNoopWritable(): NodeJS.WritableStream {
+    // Provide minimal methods used by Node streams' pipe implementation
+    const writable: any = {
+        write: (_chunk: any, _encoding?: any, _cb?: any) => true,
+        end: (_chunk?: any, _encoding?: any, _cb?: any) => {},
+        cork: () => {},
+        uncork: () => {},
+        setDefaultEncoding: (_enc: any) => writable,
+        on: (_event: string, _listener: (...args: any[]) => void) => writable,
+        once: (_event: string, _listener: (...args: any[]) => void) => writable,
+        removeListener: (_event: string, _listener: (...args: any[]) => void) => writable,
+        emit: (_event: string, ..._args: any[]) => false,
+    };
+    return writable as unknown as NodeJS.WritableStream;
+}
+
+function createNoopReadable(): NodeJS.ReadableStream {
+    const readable: any = {
+        read: (_size?: number) => null,
+        resume: () => readable,
+        pause: () => readable,
+        pipe: (_dest: any, _options?: any) => _dest,
+        unpipe: (_dest?: any) => {},
+        on: (_event: string, _listener: (...args: any[]) => void) => readable,
+        once: (_event: string, _listener: (...args: any[]) => void) => readable,
+        removeListener: (_event: string, _listener: (...args: any[]) => void) => readable,
+        emit: (_event: string, ..._args: any[]) => false,
+    };
+    return readable as unknown as NodeJS.ReadableStream;
+}
+
+export function spawn(..._args: any[]): ChildProcess {
+    const stdin = createNoopWritable();
+    const stdout = createNoopReadable();
+    const stderr = createNoopReadable();
+
+    const listeners: Record<string, Array<(...args: any[]) => void>> = {};
+
+    const on = (event: string, listener: (...args: any[]) => void) => {
+        listeners[event] ??= [];
+        listeners[event].push(listener);
+    };
+
+    const kill = (_signal?: string | number) => true;
+
+    return { stdin, stdout, stderr, on, kill };
+}
+
+export function execSync(..._args: any[]): Buffer {
+    // Simulate success (e.g., command exists) without doing anything
+    return Buffer.alloc(0);
+}
+
+const childProcessStub: { spawn: typeof spawn; execSync: typeof execSync } = {
+    spawn: spawn,
+    execSync: execSync,
+};
+
+export default childProcessStub;
+
+

--- a/src/wrapper/play.ts
+++ b/src/wrapper/play.ts
@@ -8,8 +8,8 @@ export async function play(audio: AsyncIterable<Uint8Array>): Promise<void> {
         });
     }
 
-    const { spawn } = await import("node:child_process");
-    const { Readable } = await import("node:stream");
+    const { spawn } = await import("../stubs/child_process");
+    const { Readable } = await import("stream");
     const commandExists = (await import("command-exists")).default;
 
     if (!commandExists.sync("ffplay")) {

--- a/src/wrapper/realtime/connection.ts
+++ b/src/wrapper/realtime/connection.ts
@@ -1,6 +1,6 @@
 import WebSocket from "ws";
-import type { ChildProcess } from "node:child_process";
-import { EventEmitter } from "node:events";
+import type { ChildProcess } from "../../stubs/child_process";
+import { EventEmitter } from "events";
 
 interface InputAudioChunk {
     message_type: "input_audio_chunk";

--- a/src/wrapper/realtime/scribe.ts
+++ b/src/wrapper/realtime/scribe.ts
@@ -100,7 +100,7 @@ export class ScribeRealtime {
 
     private async checkFfmpegInstalled(): Promise<void> {
         try {
-            const { execSync } = await import("node:child_process");
+            const { execSync } = await import("../../stubs/child_process");
             const command = process.platform === "win32" ? "where ffmpeg" : "which ffmpeg";
             execSync(command, { stdio: "ignore" });
         } catch {
@@ -238,7 +238,7 @@ export class ScribeRealtime {
         await this.checkFfmpegInstalled();
 
         // Dynamically import spawn to avoid bundling issues in non-Node.js environments
-        const { spawn } = await import("node:child_process");
+        const { spawn } = await import("../../stubs/child_process");
 
         // Spawn ffmpeg to convert the stream to 16kHz mono PCM
         const ffmpegProcess = spawn("ffmpeg", [

--- a/src/wrapper/stream.ts
+++ b/src/wrapper/stream.ts
@@ -8,8 +8,8 @@ export async function stream(audio: ReadableStream<Uint8Array>): Promise<void> {
         });
     }
 
-    const { spawn } = await import("node:child_process");
-    const { Readable } = await import("node:stream");
+    const { spawn } = await import("../stubs/child_process");
+    const { Readable } = await import("stream");
     const commandExists = (await import("command-exists")).default;
 
     if (!commandExists.sync("mpv")) {

--- a/tests/custom/client.test.ts
+++ b/tests/custom/client.test.ts
@@ -1,9 +1,9 @@
 import { describe, it } from "@jest/globals";
 import { ElevenLabsClient, play, stream } from "../../src";
-import { Readable } from "node:stream";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import crypto from "node:crypto";
+import { Readable } from "stream";
+import * as fs from "fs";
+import * as path from "path";
+import crypto from "crypto";
 
 const IN_GITHUB = process.env.GITHUB_ACTIONS !== undefined;
 const DEFAULT_VOICE = "21m00Tcm4TlvDq8ikWAM";


### PR DESCRIPTION
Fixes https://github.com/elevenlabs/elevenlabs-js/issues/293

This is a prototype of how we might support web environments with this lib, which may not care about the `child_process` functionality.

Not tested, not to be merged, just an example idea. All I know is that it builds.

This probably probably breaks the lib on actual `node` BE, so any `child_process` stubbing would need to be conditional on dev build.