### PR TITLE
feat: allow for general messages to be intercepted

### DIFF
--- a/src/api/resources/conversationalAi/conversation/Conversation.ts
+++ b/src/api/resources/conversationalAi/conversation/Conversation.ts
@@ -59,6 +59,7 @@ export class Conversation extends EventEmitter {
         callbackAgentResponseCorrection?: (original: string, corrected: string) => void;
         callbackUserTranscript?: (transcript: string) => void;
         callbackLatencyMeasurement?: (latencyMs: number) => void;
+        callbackMessageReceived?: (message: any) => void;
     }) {
         super();
 
@@ -75,6 +76,7 @@ export class Conversation extends EventEmitter {
         this.callbackAgentResponseCorrection = options.callbackAgentResponseCorrection;
         this.callbackUserTranscript = options.callbackUserTranscript;
         this.callbackLatencyMeasurement = options.callbackLatencyMeasurement;
+        this.callbackMessageReceived = options.callbackMessageReceived;
     }
 
     /**


### PR DESCRIPTION
Adds support for the "agent_tool_response" message that is not currently documented in the official documentation, but via a general "message" handler that allows you to intercept raw messages in addition to the other callbacks.

It would be great if the user had full control of all messages received, well-knowing the consequences that follow from this.