### PR TITLE
Add audio_format parameter if specified to Scribe WS URI

### DIFF
--- a/src/wrapper/realtime/scribe.ts
+++ b/src/wrapper/realtime/scribe.ts
@@ -166,6 +166,10 @@ export class ScribeRealtime {
             params.append("include_timestamps", options.includeTimestamps.toString());
         }
 
+        if (options.audioFormat !== undefined) {
+            params.append("audio_format", options.audioFormat);
+        }
+
         const queryString = params.toString();
         return queryString ? `${baseUri}?${queryString}` : baseUri;
     }


### PR DESCRIPTION
The ElevenLabs API documents an `audio_format` parameter that can be provided to the realtime API. While the SDK allows passing this parameter, it was previously unused in the construction of the URI.