### PR TITLE
Add overloaded convert signatures to SpeechToText wrapper

### DIFF
--- a/src/wrapper/speechToText.ts
+++ b/src/wrapper/speechToText.ts
@@ -1,4 +1,7 @@
 import { SpeechToTextClient as GeneratedSpeechToText } from "../api/resources/speechToText/client/Client";
+import type { SpeechToTextClient } from "../api/resources/speechToText/client/Client";
+import type * as ElevenLabs from "../api";
+import type * as core from "../core";
 import { ScribeRealtime } from "./realtime";
 
 export class SpeechToText extends GeneratedSpeechToText {
@@ -10,5 +13,26 @@ export class SpeechToText extends GeneratedSpeechToText {
         }
         return this._realtime;
     }
-}
 
+    public convert(
+        request: ElevenLabs.BodySpeechToTextV1SpeechToTextPost & { webhook: true },
+        requestOptions?: SpeechToTextClient.RequestOptions,
+    ): core.HttpResponsePromise<ElevenLabs.SpeechToTextWebhookResponseModel>;
+
+    public convert(
+        request: ElevenLabs.BodySpeechToTextV1SpeechToTextPost & { useMultiChannel: true },
+        requestOptions?: SpeechToTextClient.RequestOptions,
+    ): core.HttpResponsePromise<ElevenLabs.MultichannelSpeechToTextResponseModel>;
+
+    public convert(
+        request: ElevenLabs.BodySpeechToTextV1SpeechToTextPost,
+        requestOptions?: SpeechToTextClient.RequestOptions,
+    ): core.HttpResponsePromise<ElevenLabs.SpeechToTextChunkResponseModel>;
+
+    public convert(
+        request: ElevenLabs.BodySpeechToTextV1SpeechToTextPost,
+        requestOptions?: SpeechToTextClient.RequestOptions,
+    ): core.HttpResponsePromise<ElevenLabs.SpeechToTextConvertResponse> {
+        return super.convert(request, requestOptions);
+    }
+}


### PR DESCRIPTION
Narrow the return type of speechToText.convert() based on request parameters so users can access .text, .transcripts, or webhook fields without manual type narrowing.

Fixes https://github.com/elevenlabs/elevenlabs-js/issues/340