### PR TITLE
Add keyterms and noVerbatim to Scribe realtime API

### DIFF
--- a/src/wrapper/realtime/connection.ts
+++ b/src/wrapper/realtime/connection.ts
@@ -35,6 +35,8 @@ export interface Config {
     model_id?: string;
     disable_logging?: boolean;
     include_timestamps?: boolean;
+    keyterms?: string[];
+    no_verbatim?: boolean;
 }
 
 export interface SessionStartedMessage {

--- a/src/wrapper/realtime/scribe.ts
+++ b/src/wrapper/realtime/scribe.ts
@@ -60,6 +60,16 @@ interface BaseOptions {
      * @default false
      */
     includeTimestamps?: boolean;
+    /**
+     * List of keyterms to bias the model towards.
+     * Maximum 50 keyterms, each up to 20 characters.
+     */
+    keyterms?: string[];
+    /**
+     * If true, removes filler words, false starts and disfluencies from the transcript.
+     * @default false
+     */
+    noVerbatim?: boolean;
 }
 
 export interface AudioOptions extends BaseOptions {
@@ -167,6 +177,15 @@ export class ScribeRealtime {
 
         if (options.includeTimestamps !== undefined) {
             params.append("include_timestamps", options.includeTimestamps.toString());
+        }
+
+        if (options.keyterms !== undefined) {
+            for (const term of options.keyterms) {
+                params.append("keyterms", term);
+            }
+        }
+        if (options.noVerbatim !== undefined) {
+            params.append("no_verbatim", options.noVerbatim ? "true" : "false");
         }
 
         if (options.audioFormat !== undefined) {

--- a/tests/custom/scribe.test.ts
+++ b/tests/custom/scribe.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+// Mock `ws` before importing ScribeRealtime so it never opens a real socket.
+let capturedUrl: string | undefined;
+jest.mock("ws", () => {
+    return {
+        __esModule: true,
+        default: class FakeWebSocket {
+            static OPEN = 1;
+            readyState = 0;
+            constructor(url: string) {
+                capturedUrl = url;
+            }
+            on() {}
+            send() {}
+            close() {}
+        },
+    };
+});
+
+import { ScribeRealtime, AudioFormat } from "../../src/wrapper/realtime/scribe";
+
+const TEST_API_KEY = "test_api_key";
+const TEST_MODEL_ID = "scribe_v2_realtime";
+
+async function connectAndGetUrl(
+    overrides: Record<string, unknown> = {}
+): Promise<URL> {
+    const scribe = new ScribeRealtime({ apiKey: TEST_API_KEY });
+    capturedUrl = undefined;
+
+    const connection = await scribe.connect({
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+        ...overrides,
+    });
+    connection.close();
+
+    if (!capturedUrl) {
+        throw new Error("WebSocket was never constructed");
+    }
+    return new URL(capturedUrl);
+}
+
+describe("ScribeRealtime URI building", () => {
+    beforeEach(() => {
+        capturedUrl = undefined;
+    });
+
+    it("includes keyterms as repeated query params", async () => {
+        const url = await connectAndGetUrl({
+            keyterms: ["ElevenLabs", "Scribe"],
+        });
+
+        const keyterms = url.searchParams.getAll("keyterms");
+        expect(keyterms).toEqual(["ElevenLabs", "Scribe"]);
+    });
+
+    it("includes no_verbatim=true when noVerbatim is true", async () => {
+        const url = await connectAndGetUrl({ noVerbatim: true });
+
+        expect(url.searchParams.get("no_verbatim")).toBe("true");
+    });
+
+    it("includes no_verbatim=false when noVerbatim is false", async () => {
+        const url = await connectAndGetUrl({ noVerbatim: false });
+
+        expect(url.searchParams.get("no_verbatim")).toBe("false");
+    });
+
+    it("omits keyterms and no_verbatim when not specified", async () => {
+        const url = await connectAndGetUrl();
+
+        expect(url.searchParams.has("keyterms")).toBe(false);
+        expect(url.searchParams.has("no_verbatim")).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Add `keyterms` option (`string[]`) to bias the Scribe model towards specific terms (max 50 keyterms, each up to 20 chars). Passed as repeated query params on the WebSocket URL.
- Add `noVerbatim` option (`boolean`) to remove filler words, false starts, and disfluencies from transcripts.
- Add `keyterms` and `no_verbatim` to the `Config` interface for typed server echo in `session_started`.

Mirrors elevenlabs/packages#690.

## Test plan
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Unit tests for `keyterms` repeated query params
- [x] Unit tests for `noVerbatim` true/false query param
- [x] Unit test confirming params omitted when not specified
- [x] All files edited are in `.fernignore` (hand-maintained)
- [ ] Manual verification with a real Scribe realtime session using `keyterms`
- [ ] Manual verification with `noVerbatim: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)