### PR TITLE
Add environment configuration to conversation initiation data and events

### DIFF
--- a/src/api/resources/conversationalAi/conversation/Conversation.ts
+++ b/src/api/resources/conversationalAi/conversation/Conversation.ts
@@ -243,6 +243,7 @@ export class Conversation extends EventEmitter {
             custom_llm_extra_body: this.config.extraBody,
             conversation_config_override: this.config.conversationConfigOverride,
             dynamic_variables: this.config.dynamicVariables,
+            environment: this.config.environment,
         };
 
         this.ws!.send(JSON.stringify(initEvent));

--- a/src/api/resources/conversationalAi/conversation/ConversationConfig.ts
+++ b/src/api/resources/conversationalAi/conversation/ConversationConfig.ts
@@ -8,6 +8,8 @@ export interface ConversationInitiationData {
     conversationConfigOverride?: Record<string, any>;
     /** Dynamic variables to use in the conversation */
     dynamicVariables?: Record<string, any>;
+    /** The environment to use for the conversation */
+    environment?: string;
 }
 
 /**

--- a/src/api/resources/conversationalAi/conversation/events.ts
+++ b/src/api/resources/conversationalAi/conversation/events.ts
@@ -54,6 +54,7 @@ export interface ConversationInitiationClientDataEvent extends BaseClientToOrche
     custom_llm_extra_body?: Record<string, any>;
     conversation_config_override?: Record<string, any>;
     dynamic_variables?: Record<string, any>;
+    environment?: string;
 }
 
 /**


### PR DESCRIPTION
`environment` was missing as a conversation_initialization field.