### PR TITLE
[Speech Engine] Add full response to Speech Engine API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@elevenlabs/elevenlabs-js",
-    "version": "2.49.0",
+    "version": "2.49.1",
     "private": false,
     "repository": "github:elevenlabs/elevenlabs-js",
     "license": "MIT",

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -47,8 +47,8 @@ export function normalizeClientOptions<T extends BaseClientOptions>(options: T):
         {
             "X-Fern-Language": "JavaScript",
             "X-Fern-SDK-Name": "@elevenlabs/elevenlabs-js",
-            "X-Fern-SDK-Version": "2.49.0",
-            "User-Agent": "@elevenlabs/elevenlabs-js/2.49.0",
+            "X-Fern-SDK-Version": "2.49.1",
+            "User-Agent": "@elevenlabs/elevenlabs-js/2.49.1",
             "X-Fern-Runtime": core.RUNTIME.type,
             "X-Fern-Runtime-Version": core.RUNTIME.version,
             "xi-api-key": options?.apiKey,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "2.49.0";
+export const SDK_VERSION = "2.49.1";

--- a/src/wrapper/speech-engine/SpeechEngineClientWrapper.ts
+++ b/src/wrapper/speech-engine/SpeechEngineClientWrapper.ts
@@ -55,7 +55,7 @@ export class SpeechEngineClientWrapper extends SpeechEngineClient {
         requestOptions?: SpeechEngineClient.RequestOptions,
     ): Promise<SpeechEngineResource> {
         const response = await super.create(request, requestOptions);
-        return new SpeechEngineResource(response.speechEngineId, this._options);
+        return new SpeechEngineResource(response.speechEngineId, this._options, response);
     }
 
     /**
@@ -80,8 +80,8 @@ export class SpeechEngineClientWrapper extends SpeechEngineClient {
         speechEngineId: string,
         requestOptions?: SpeechEngineClient.RequestOptions,
     ): Promise<SpeechEngineResource> {
-        await super.get(speechEngineId, requestOptions);
-        return new SpeechEngineResource(speechEngineId, this._options);
+        const response = await super.get(speechEngineId, requestOptions);
+        return new SpeechEngineResource(speechEngineId, this._options, response);
     }
 
     /**
@@ -107,8 +107,8 @@ export class SpeechEngineClientWrapper extends SpeechEngineClient {
         request: UpdateSpeechEngineRequest = {},
         requestOptions?: SpeechEngineClient.RequestOptions,
     ): Promise<SpeechEngineResource> {
-        await super.update(speechEngineId, request, requestOptions);
-        return new SpeechEngineResource(speechEngineId, this._options);
+        const response = await super.update(speechEngineId, request, requestOptions);
+        return new SpeechEngineResource(speechEngineId, this._options, response);
     }
 
     /**

--- a/src/wrapper/speech-engine/SpeechEngineResource.ts
+++ b/src/wrapper/speech-engine/SpeechEngineResource.ts
@@ -4,6 +4,7 @@ import type { Duplex } from "node:stream";
 import WebSocket from "ws";
 import type { BaseClientOptions, NormalizedClientOptions } from "../../BaseClient";
 import * as core from "../../core";
+import type * as ElevenLabs from "../../api/types";
 import { isAbortError, type SpeechEngineCallbacks } from "./types";
 import { SpeechEngineSession } from "./SpeechEngineSession";
 import { SpeechEngineAttachment } from "./SpeechEngineAttachment";
@@ -28,13 +29,50 @@ import { SpeechEngineAttachment } from "./SpeechEngineAttachment";
  */
 export class SpeechEngineResource {
     readonly engineId: string;
+
+    /**
+     * Response fields from the API. These are populated when the resource is
+     * returned from `create()`, `get()`, or `update()`.
+     *
+     * When using the `attach()` shortcut directly, no API call is made so
+     * these fields will be `undefined`.
+     */
+    readonly name: string | undefined;
+    readonly speechEngine: ElevenLabs.SpeechEngineConfig | undefined;
+    readonly asr: ElevenLabs.AsrConversationalConfig | undefined;
+    readonly tts: ElevenLabs.TtsConversationalConfigOutput | undefined;
+    readonly turn: ElevenLabs.BaseTurnConfig | undefined;
+    readonly conversation: ElevenLabs.ConversationConfigOutput | undefined;
+    readonly privacy: ElevenLabs.PrivacyConfigOutput | undefined;
+    readonly callLimits: ElevenLabs.AgentCallLimits | undefined;
+    readonly language: string | undefined;
+    readonly tags: string[] | undefined;
+    readonly overrides: ElevenLabs.SpeechEngineConversationInitiationClientDataConfig | undefined;
+    readonly metadata: ElevenLabs.AgentMetadataDbModel | undefined;
+
     /** @internal */
     readonly _options: NormalizedClientOptions<BaseClientOptions>;
 
     /** @internal */
-    constructor(engineId: string, options: NormalizedClientOptions<BaseClientOptions>) {
+    constructor(
+        engineId: string,
+        options: NormalizedClientOptions<BaseClientOptions>,
+        response?: ElevenLabs.SpeechEngineResponse,
+    ) {
         this.engineId = engineId;
         this._options = options;
+        this.name = response?.name;
+        this.speechEngine = response?.speechEngine;
+        this.asr = response?.asr;
+        this.tts = response?.tts;
+        this.turn = response?.turn;
+        this.conversation = response?.conversation;
+        this.privacy = response?.privacy;
+        this.callLimits = response?.callLimits;
+        this.language = response?.language;
+        this.tags = response?.tags;
+        this.overrides = response?.overrides;
+        this.metadata = response?.metadata;
     }
 
     /**

--- a/src/wrapper/speech-engine/SpeechEngineResource.ts
+++ b/src/wrapper/speech-engine/SpeechEngineResource.ts
@@ -28,51 +28,32 @@ import { SpeechEngineAttachment } from "./SpeechEngineAttachment";
  * ```
  */
 export class SpeechEngineResource {
-    readonly engineId: string;
+    readonly id: string;
 
     /**
-     * Response fields from the API. These are populated when the resource is
+     * Full configuration returned by the API. Populated when the resource is
      * returned from `create()`, `get()`, or `update()`.
      *
-     * When using the `attach()` shortcut directly, no API call is made so
-     * these fields will be `undefined`.
+     * `undefined` when using the `attach()` shortcut directly, since no API
+     * call is made in that case.
      */
-    readonly name: string | undefined;
-    readonly speechEngine: ElevenLabs.SpeechEngineConfig | undefined;
-    readonly asr: ElevenLabs.AsrConversationalConfig | undefined;
-    readonly tts: ElevenLabs.TtsConversationalConfigOutput | undefined;
-    readonly turn: ElevenLabs.BaseTurnConfig | undefined;
-    readonly conversation: ElevenLabs.ConversationConfigOutput | undefined;
-    readonly privacy: ElevenLabs.PrivacyConfigOutput | undefined;
-    readonly callLimits: ElevenLabs.AgentCallLimits | undefined;
-    readonly language: string | undefined;
-    readonly tags: string[] | undefined;
-    readonly overrides: ElevenLabs.SpeechEngineConversationInitiationClientDataConfig | undefined;
-    readonly metadata: ElevenLabs.AgentMetadataDbModel | undefined;
+    readonly config: Omit<ElevenLabs.SpeechEngineResponse, "speechEngineId"> | undefined;
 
     /** @internal */
     readonly _options: NormalizedClientOptions<BaseClientOptions>;
 
     /** @internal */
     constructor(
-        engineId: string,
+        id: string,
         options: NormalizedClientOptions<BaseClientOptions>,
         response?: ElevenLabs.SpeechEngineResponse,
     ) {
-        this.engineId = engineId;
+        this.id = id;
         this._options = options;
-        this.name = response?.name;
-        this.speechEngine = response?.speechEngine;
-        this.asr = response?.asr;
-        this.tts = response?.tts;
-        this.turn = response?.turn;
-        this.conversation = response?.conversation;
-        this.privacy = response?.privacy;
-        this.callLimits = response?.callLimits;
-        this.language = response?.language;
-        this.tags = response?.tags;
-        this.overrides = response?.overrides;
-        this.metadata = response?.metadata;
+        if (response) {
+            const { speechEngineId: _id, ...config } = response;
+            this.config = config;
+        }
     }
 
     /**

--- a/src/wrapper/speech-engine/SpeechEngineResource.ts
+++ b/src/wrapper/speech-engine/SpeechEngineResource.ts
@@ -28,7 +28,7 @@ import { SpeechEngineAttachment } from "./SpeechEngineAttachment";
  * ```
  */
 export class SpeechEngineResource {
-    readonly id: string;
+    readonly engineId: string;
 
     /**
      * Full configuration returned by the API. Populated when the resource is
@@ -44,11 +44,11 @@ export class SpeechEngineResource {
 
     /** @internal */
     constructor(
-        id: string,
+        engineId: string,
         options: NormalizedClientOptions<BaseClientOptions>,
         response?: ElevenLabs.SpeechEngineResponse,
     ) {
-        this.id = id;
+        this.engineId = engineId;
         this._options = options;
         if (response) {
             const { speechEngineId: _id, ...config } = response;


### PR DESCRIPTION
We currently override the response from the `get`, `create` and `update` methods to return a Speech Engine resource instead of a response. That also means that the data returned from the API is lost to the end user. This adds it back as part of a `config` object that can be accessed. e.g.

```ts
const engine = elevenlabs.speechEngine.create({
  name: "My engine",
  speechEngine: {
    wsUrl: "wss://example.com",
  },
});

console.log(engine.config.name); // "My engine"

engine.attach(...);
```