### PR TITLE
Fix workflow expression LLM AST serialization

### DIFF
--- a/src/api/types/AstNodeInput.ts
+++ b/src/api/types/AstNodeInput.ts
@@ -60,9 +60,8 @@ export namespace AstNodeInput {
         type: "gte_operator";
     }
 
-    export interface Llm {
+    export interface Llm extends ElevenLabs.AstllmNodeInputValueSchema {
         type: "llm";
-        value: ElevenLabs.AstllmNodeInput;
     }
 
     export interface LtOperator extends ElevenLabs.AstLessThanOperatorNodeInput {

--- a/src/serialization/types/AstNodeInput.ts
+++ b/src/serialization/types/AstNodeInput.ts
@@ -5,7 +5,7 @@ import * as core from "../../core";
 import * as serializers from "../index";
 import { AstBooleanNodeInput } from "./AstBooleanNodeInput";
 import { AstDynamicVariableNodeInput } from "./AstDynamicVariableNodeInput";
-import { AstllmNodeInput } from "./AstllmNodeInput";
+import { AstllmNodeInputValueSchema } from "./AstllmNodeInputValueSchema";
 import { AstNullNodeInput } from "./AstNullNodeInput";
 import { AstNumberNodeInput } from "./AstNumberNodeInput";
 import { AstStringNodeInput } from "./AstStringNodeInput";
@@ -22,9 +22,7 @@ export const AstNodeInput: core.serialization.Schema<serializers.AstNodeInput.Ra
             eq_operator: core.serialization.lazyObject(() => serializers.AstEqualsOperatorNodeInput),
             gt_operator: core.serialization.lazyObject(() => serializers.AstGreaterThanOperatorNodeInput),
             gte_operator: core.serialization.lazyObject(() => serializers.AstGreaterThanOrEqualsOperatorNodeInput),
-            llm: core.serialization.object({
-                value: AstllmNodeInput,
-            }),
+            llm: AstllmNodeInputValueSchema,
             lt_operator: core.serialization.lazyObject(() => serializers.AstLessThanOperatorNodeInput),
             lte_operator: core.serialization.lazyObject(() => serializers.AstLessThanOrEqualsOperatorNodeInput),
             mul_operator: core.serialization.lazyObject(() => serializers.AstMultiplicationOperatorNodeInput),
@@ -98,9 +96,8 @@ export declare namespace AstNodeInput {
         type: "gte_operator";
     }
 
-    export interface Llm {
+    export interface Llm extends AstllmNodeInputValueSchema.Raw {
         type: "llm";
-        value: AstllmNodeInput.Raw;
     }
 
     export interface LtOperator extends serializers.AstLessThanOperatorNodeInput.Raw {

--- a/tests/unit/conversationalAi/workflowExpressionAst.test.ts
+++ b/tests/unit/conversationalAi/workflowExpressionAst.test.ts
@@ -1,0 +1,59 @@
+import { AgentWorkflowRequestModel } from "../../../src/serialization";
+
+describe("AgentWorkflowRequestModel", () => {
+    it("serializes flat LLM AST nodes in expression edge conditions", () => {
+        const workflow = {
+            edges: {
+                edge_01kqshbn29fagvdxghkpwgae5n: {
+                    source: "start_node",
+                    target: "booking_node",
+                    forwardCondition: {
+                        type: "expression",
+                        expression: {
+                            type: "and_operator",
+                            children: [
+                                {
+                                    type: "neq_operator",
+                                    left: { type: "dynamic_variable", name: "system__caller_id" },
+                                    right: { type: "null_literal" },
+                                },
+                                {
+                                    type: "llm",
+                                    valueSchema: {
+                                        type: "boolean",
+                                        description: "customer expressed intention to book an appointment",
+                                    },
+                                    prompt: "customer expressed intention to book an appointment",
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+
+        const raw = AgentWorkflowRequestModel.jsonOrThrow(workflow, {
+            unrecognizedObjectKeys: "strip",
+        });
+
+        expect(
+            raw.edges?.edge_01kqshbn29fagvdxghkpwgae5n.forward_condition?.expression,
+        ).toEqual({
+            type: "and_operator",
+            children: [
+                {
+                    type: "neq_operator",
+                    left: { type: "dynamic_variable", name: "system__caller_id" },
+                    right: { type: "null_literal" },
+                },
+                {
+                    type: "llm",
+                    value_schema: {
+                        type: "boolean",
+                        description: "customer expressed intention to book an appointment",
+                    },
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Serialize workflow expression `llm` AST nodes as flat `{ type: "llm", value_schema: ... }` request payloads instead of wrapping under `value`.
- Align `AstNodeInput.Llm` request types with `AstllmNodeInputValueSchema`.
- Add a regression test for an expression edge condition with both deterministic and LLM children.

## Context
Pulling an agent config can return a flat LLM expression node with `value_schema`. The request serializer expected `{ type: "llm", value: ... }`, so pushing the pulled config failed with `Missing required key "value"` at the LLM child.

## Tests
- `yarn build`
- `yarn jest --selectProjects unit --runTestsByPath tests/unit/conversationalAi/workflowExpressionAst.test.ts --runInBand`