### PR TITLE
[fix] Restore optional values in DynamicVariablesConfig records (2.53.1)

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -17,3 +17,14 @@ tests/wire/conversationalAi/mcpServers/tools.test.ts
 .fern/replay.lock
 .fern/replay.yml
 .gitattributes
+
+# Hotfix: Fern generator 3.71.4 dropped `| undefined` from map value types.
+# Ignored until the upstream generator fix lands. See PR for context.
+src/api/types/DynamicVariablesConfigInput.ts
+src/api/types/DynamicVariablesConfigOutput.ts
+src/api/types/DynamicVariablesConfigWorkflowOverrideInput.ts
+src/api/types/DynamicVariablesConfigWorkflowOverrideOutput.ts
+src/serialization/types/DynamicVariablesConfigInput.ts
+src/serialization/types/DynamicVariablesConfigOutput.ts
+src/serialization/types/DynamicVariablesConfigWorkflowOverrideInput.ts
+src/serialization/types/DynamicVariablesConfigWorkflowOverrideOutput.ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@elevenlabs/elevenlabs-js",
-    "version": "2.53.0",
+    "version": "2.53.1",
     "private": false,
     "repository": {
         "type": "git",

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -49,8 +49,8 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
         {
             "X-Fern-Language": "JavaScript",
             "X-Fern-SDK-Name": "@elevenlabs/elevenlabs-js",
-            "X-Fern-SDK-Version": "2.53.0",
-            "User-Agent": "@elevenlabs/elevenlabs-js/2.53.0",
+            "X-Fern-SDK-Version": "2.53.1",
+            "User-Agent": "@elevenlabs/elevenlabs-js/2.53.1",
             "X-Fern-Runtime": core.RUNTIME.type,
             "X-Fern-Runtime-Version": core.RUNTIME.version,
             "xi-api-key": options?.apiKey,

--- a/src/api/types/DynamicVariablesConfigInput.ts
+++ b/src/api/types/DynamicVariablesConfigInput.ts
@@ -4,5 +4,5 @@ import type * as ElevenLabs from "../index";
 
 export interface DynamicVariablesConfigInput {
     /** A dictionary of dynamic variable placeholders and their values */
-    dynamicVariablePlaceholders?: Record<string, ElevenLabs.DynamicVariableValueTypeInput>;
+    dynamicVariablePlaceholders?: Record<string, ElevenLabs.DynamicVariableValueTypeInput | undefined>;
 }

--- a/src/api/types/DynamicVariablesConfigOutput.ts
+++ b/src/api/types/DynamicVariablesConfigOutput.ts
@@ -4,5 +4,5 @@ import type * as ElevenLabs from "../index";
 
 export interface DynamicVariablesConfigOutput {
     /** A dictionary of dynamic variable placeholders and their values */
-    dynamicVariablePlaceholders?: Record<string, ElevenLabs.DynamicVariableValueTypeOutput>;
+    dynamicVariablePlaceholders?: Record<string, ElevenLabs.DynamicVariableValueTypeOutput | undefined>;
 }

--- a/src/api/types/DynamicVariablesConfigWorkflowOverrideInput.ts
+++ b/src/api/types/DynamicVariablesConfigWorkflowOverrideInput.ts
@@ -4,5 +4,5 @@ import type * as ElevenLabs from "../index";
 
 export interface DynamicVariablesConfigWorkflowOverrideInput {
     /** A dictionary of dynamic variable placeholders and their values */
-    dynamicVariablePlaceholders?: Record<string, ElevenLabs.DynamicVariableValueTypeInput>;
+    dynamicVariablePlaceholders?: Record<string, ElevenLabs.DynamicVariableValueTypeInput | undefined>;
 }

--- a/src/api/types/DynamicVariablesConfigWorkflowOverrideOutput.ts
+++ b/src/api/types/DynamicVariablesConfigWorkflowOverrideOutput.ts
@@ -4,5 +4,5 @@ import type * as ElevenLabs from "../index";
 
 export interface DynamicVariablesConfigWorkflowOverrideOutput {
     /** A dictionary of dynamic variable placeholders and their values */
-    dynamicVariablePlaceholders?: Record<string, ElevenLabs.DynamicVariableValueTypeOutput>;
+    dynamicVariablePlaceholders?: Record<string, ElevenLabs.DynamicVariableValueTypeOutput | undefined>;
 }

--- a/src/serialization/types/DynamicVariablesConfigInput.ts
+++ b/src/serialization/types/DynamicVariablesConfigInput.ts
@@ -11,12 +11,12 @@ export const DynamicVariablesConfigInput: core.serialization.ObjectSchema<
 > = core.serialization.object({
     dynamicVariablePlaceholders: core.serialization.property(
         "dynamic_variable_placeholders",
-        core.serialization.record(core.serialization.string(), DynamicVariableValueTypeInput).optional(),
+        core.serialization.record(core.serialization.string(), DynamicVariableValueTypeInput.optional()).optional(),
     ),
 });
 
 export declare namespace DynamicVariablesConfigInput {
     export interface Raw {
-        dynamic_variable_placeholders?: Record<string, DynamicVariableValueTypeInput.Raw | null> | null;
+        dynamic_variable_placeholders?: Record<string, DynamicVariableValueTypeInput.Raw | null | undefined> | null;
     }
 }

--- a/src/serialization/types/DynamicVariablesConfigOutput.ts
+++ b/src/serialization/types/DynamicVariablesConfigOutput.ts
@@ -11,12 +11,12 @@ export const DynamicVariablesConfigOutput: core.serialization.ObjectSchema<
 > = core.serialization.object({
     dynamicVariablePlaceholders: core.serialization.property(
         "dynamic_variable_placeholders",
-        core.serialization.record(core.serialization.string(), DynamicVariableValueTypeOutput).optional(),
+        core.serialization.record(core.serialization.string(), DynamicVariableValueTypeOutput.optional()).optional(),
     ),
 });
 
 export declare namespace DynamicVariablesConfigOutput {
     export interface Raw {
-        dynamic_variable_placeholders?: Record<string, DynamicVariableValueTypeOutput.Raw | null> | null;
+        dynamic_variable_placeholders?: Record<string, DynamicVariableValueTypeOutput.Raw | null | undefined> | null;
     }
 }

--- a/src/serialization/types/DynamicVariablesConfigWorkflowOverrideInput.ts
+++ b/src/serialization/types/DynamicVariablesConfigWorkflowOverrideInput.ts
@@ -11,12 +11,12 @@ export const DynamicVariablesConfigWorkflowOverrideInput: core.serialization.Obj
 > = core.serialization.object({
     dynamicVariablePlaceholders: core.serialization.property(
         "dynamic_variable_placeholders",
-        core.serialization.record(core.serialization.string(), DynamicVariableValueTypeInput).optional(),
+        core.serialization.record(core.serialization.string(), DynamicVariableValueTypeInput.optional()).optional(),
     ),
 });
 
 export declare namespace DynamicVariablesConfigWorkflowOverrideInput {
     export interface Raw {
-        dynamic_variable_placeholders?: Record<string, DynamicVariableValueTypeInput.Raw | null> | null;
+        dynamic_variable_placeholders?: Record<string, DynamicVariableValueTypeInput.Raw | null | undefined> | null;
     }
 }

--- a/src/serialization/types/DynamicVariablesConfigWorkflowOverrideOutput.ts
+++ b/src/serialization/types/DynamicVariablesConfigWorkflowOverrideOutput.ts
@@ -11,12 +11,12 @@ export const DynamicVariablesConfigWorkflowOverrideOutput: core.serialization.Ob
 > = core.serialization.object({
     dynamicVariablePlaceholders: core.serialization.property(
         "dynamic_variable_placeholders",
-        core.serialization.record(core.serialization.string(), DynamicVariableValueTypeOutput).optional(),
+        core.serialization.record(core.serialization.string(), DynamicVariableValueTypeOutput.optional()).optional(),
     ),
 });
 
 export declare namespace DynamicVariablesConfigWorkflowOverrideOutput {
     export interface Raw {
-        dynamic_variable_placeholders?: Record<string, DynamicVariableValueTypeOutput.Raw | null> | null;
+        dynamic_variable_placeholders?: Record<string, DynamicVariableValueTypeOutput.Raw | null | undefined> | null;
     }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "2.53.0";
+export const SDK_VERSION = "2.53.1";


### PR DESCRIPTION
## Summary

The 2.53.0 regen bumped `fernapi/fern-typescript-sdk` from **3.36.0** to **3.71.4**, which dropped `| undefined` from the value type of `Record<string, T>` types backed by OpenAPI `additionalProperties`. This is a breaking change for callers that set individual `dynamicVariablePlaceholders` entries to `undefined` (common in non-telephony flows where not every placeholder can be assigned).

The OpenAPI spec for `DynamicVariablesConfig-Input/Output` and `DynamicVariableValueType-Input/Output` did not change. The regression is entirely in the generator.

### Diff in 2.53.0 we are reverting

```ts
// before (2.52.x)
dynamicVariablePlaceholders?: Record<string, DynamicVariableValueTypeInput | undefined>;
// after (2.53.0)
dynamicVariablePlaceholders?: Record<string, DynamicVariableValueTypeInput>;
```

Same change in `DynamicVariablesConfigOutput`, `DynamicVariablesConfigWorkflowOverrideInput`, `DynamicVariablesConfigWorkflowOverrideOutput`, and their `src/serialization/types/` counterparts (where `record(string(), T.optional())` became `record(string(), T)`).

## Changes

- Restored `| undefined` on the four `Record` value types in `src/api/types/`.
- Restored `.optional()` on the four serializer `record(...)` values and `| undefined` on the matching `Raw` declarations in `src/serialization/types/`.
- Added the eight paths to `.fernignore` so the next regen does not undo the workaround.
- Bumped SDK version to `2.53.1` (`package.json`, `src/version.ts`, `src/BaseClient.ts` headers).

## Follow-up

Filing a Fern bug for the `fern-typescript-sdk` 3.36.0 → 3.71.4 regression. Once that ships, remove these eight paths from `.fernignore` and let regen take over.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Existing dynamic variables tests still pass
- [x] Confirm a consumer can again assign `undefined` to an individual `dynamicVariablePlaceholders` key without a type error

---

_Written by Claude Opus 4.7, using Claude Code._