### PR TITLE
Bump checkout and setup-node actions from v3 to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
 
         steps:
             - name: Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v5
 
             - name: Set up node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v5
 
             - name: Compile
               run: yarn && yarn build
@@ -21,10 +21,10 @@ jobs:
 
         steps:
             - name: Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v5
 
             - name: Set up node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v5
 
             - name: Compile
               run: yarn && yarn test
@@ -40,9 +40,9 @@ jobs:
             id-token: write
         steps:
             - name: Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v5
             - name: Set up node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v5
             - name: Install dependencies
               run: yarn install
             - name: Build


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` and `actions/setup-node` from `@v3` to `@v5` across the `compile`, `test`, and `publish` jobs
- Resolves the GitHub CI warning: *"Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24"*

## Notes
- `actions/checkout@v5` and `actions/setup-node@v5` both run on Node.js 24
- `setup-node@v5` auto-caches dependencies when `packageManager` is set in `package.json` — this repo has `"packageManager": "yarn@1.22.22"`, so Yarn's cache will start being persisted between runs (faster CI, no input change required)
- No workflow inputs or outputs change; existing OIDC publish flow is untouched

## Test plan
- [x] CI passes on this PR (`compile` and `test` jobs)
- [x] No new deprecation warnings in the Actions run summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)