### PR TITLE
Pin Node to lts/Krypton in CI and publish with bundled npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
               uses: actions/checkout@v5
 
             - name: Set up node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
+              with:
+                  node-version: lts/Krypton
 
             - name: Compile
               run: yarn && yarn build
@@ -24,7 +26,9 @@ jobs:
               uses: actions/checkout@v5
 
             - name: Set up node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
+              with:
+                  node-version: lts/Krypton
 
             - name: Compile
               run: yarn && yarn test
@@ -42,7 +46,9 @@ jobs:
             - name: Checkout repo
               uses: actions/checkout@v5
             - name: Set up node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
+              with:
+                  node-version: lts/Krypton
             - name: Install dependencies
               run: yarn install
             - name: Build
@@ -51,7 +57,7 @@ jobs:
             - name: Publish to npm
               run: |
                   publish() {
-                    npx -y npm@latest publish "$@"
+                    npm publish "$@"
                   }
                   if [[ ${GITHUB_REF} == *alpha* ]]; then
                     publish --access public --tag alpha


### PR DESCRIPTION
## Summary

- Upgrade actions/setup-node from v5 to v6 and pin `node-version: lts/Krypton` (Node 24) in all three CI jobs, matching the pinning used in elevenlabs-dx workflows.
- Publish with the bundled npm instead of `npx -y npm@latest publish`. npm 12.0.0 (published 2026-07-08) has a packaging bug: `libnpmpublish/lib/provenance.js` requires `sigstore`, but the module is no longer bundled anywhere on its resolution path, so every `npm publish` fails with `MODULE_NOT_FOUND` before reaching the registry. This is what broke the v2.57.0 publish run: https://github.com/elevenlabs/elevenlabs-js/actions/runs/29002660275/job/86089671090
- Node 24's bundled npm 11.x resolves sigstore correctly and supports the OIDC trusted publishing this workflow uses, and the pin means future npm releases can't break publishes out from under us.

After merging, the v2.57.0 tag needs to be moved to a commit containing this fix so the publish can be re-run.

## Test plan

- [x] Verified npm 12.0.0's tarball has no resolvable `sigstore` for `libnpmpublish` while 11.18.0 bundles it at top level
- [ ] Publish succeeds after re-tagging v2.57.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)