### PR TITLE
Add callbackAgentReasoningResponsePart support to Conversation class

### DIFF
--- a/src/api/resources/conversationalAi/conversation/Conversation.ts
+++ b/src/api/resources/conversationalAi/conversation/Conversation.ts
@@ -39,6 +39,11 @@ export class Conversation extends EventEmitter {
     private callbackUserTranscript?: (transcript: string) => void;
     private callbackLatencyMeasurement?: (latencyMs: number) => void;
     private callbackMessageReceived?: (message: any) => void;
+    private callbackAgentReasoningResponsePart?: (
+        text: string,
+        type: "start" | "delta" | "stop",
+        eventId: number,
+    ) => void;
 
     // Internal state
     private ws?: WebSocketInterface;
@@ -61,6 +66,11 @@ export class Conversation extends EventEmitter {
         callbackUserTranscript?: (transcript: string) => void;
         callbackLatencyMeasurement?: (latencyMs: number) => void;
         callbackMessageReceived?: (message: any) => void;
+        callbackAgentReasoningResponsePart?: (
+            text: string,
+            type: "start" | "delta" | "stop",
+            eventId: number,
+        ) => void;
     }) {
         super();
 
@@ -78,6 +88,7 @@ export class Conversation extends EventEmitter {
         this.callbackUserTranscript = options.callbackUserTranscript;
         this.callbackLatencyMeasurement = options.callbackLatencyMeasurement;
         this.callbackMessageReceived = options.callbackMessageReceived;
+        this.callbackAgentReasoningResponsePart = options.callbackAgentReasoningResponsePart;
     }
 
     /**
@@ -364,6 +375,17 @@ export class Conversation extends EventEmitter {
                         this.ws.send(JSON.stringify(response));
                     }
                 });
+                break;
+
+            case "agent_reasoning_response_part":
+                if (this.callbackAgentReasoningResponsePart) {
+                    const reasoningEvent = message.reasoning_response_part;
+                    this.callbackAgentReasoningResponsePart(
+                        reasoningEvent.text,
+                        reasoningEvent.type,
+                        parseInt(reasoningEvent.event_id, 10),
+                    );
+                }
                 break;
 
             default:

--- a/src/api/resources/conversationalAi/conversation/__tests__/Conversation.test.ts
+++ b/src/api/resources/conversationalAi/conversation/__tests__/Conversation.test.ts
@@ -357,6 +357,45 @@ describe("Conversation", () => {
                 }),
             );
         });
+
+        it("should handle agent reasoning response part", async () => {
+            const agentReasoningCallback = jest.fn();
+
+            conversation = new Conversation({
+                client: mockClient,
+                agentId: "test-agent-id",
+                requiresAuth: false,
+                audioInterface: mockAudioInterface,
+                callbackAgentReasoningResponsePart: agentReasoningCallback,
+            });
+
+            mockWebSocket.on.mockImplementation((event: string, callback: Function) => {
+                if (event === "open") {
+                    setTimeout(() => callback(), 0);
+                } else if (event === "message") {
+                    messageHandler = callback as (data: any) => void;
+                }
+            });
+
+            await conversation.startSession();
+
+            const message = {
+                type: "agent_reasoning_response_part",
+                reasoning_response_part: {
+                    text: "Let me think about this...",
+                    type: "delta",
+                    event_id: "42",
+                },
+            };
+
+            messageHandler(Buffer.from(JSON.stringify(message)));
+
+            expect(agentReasoningCallback).toHaveBeenCalledWith(
+                "Let me think about this...",
+                "delta",
+                42,
+            );
+        });
     });
 
     describe("client tools integration", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR adds support for the `agent_reasoning_response_part` WebSocket message type to the JS SDK's Conversation class.

## Changes

- Added `callbackAgentReasoningResponsePart` private callback property to the Conversation class
- Added corresponding option to the constructor options type
- Added assignment of the callback in the constructor body  
- Added handler for the `agent_reasoning_response_part` message type in the `_handleMessage` switch statement
- Added test for the new handler

## Callback Signature

```typescript
callbackAgentReasoningResponsePart?: (
    text: string,
    type: "start" | "delta" | "stop",
    eventId: number,
) => void;
```

The callback receives:
- `text`: The reasoning text content
- `type`: The type of reasoning event (`"start"`, `"delta"`, or `"stop"`)
- `eventId`: The numeric event ID (parsed from string)

## Usage

```typescript
const conversation = new Conversation({
    agentId: "your-agent-id",
    requiresAuth: true,
    audioInterface: yourAudioInterface,
    callbackAgentReasoningResponsePart: (text, type, eventId) => {
        console.log(`Reasoning [${type}]: ${text}`);
    },
});
```
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://eleven-labs-workspace.slack.com/archives/D094A2U16DS/p1785180333368169?thread_ts=1785180333.368169&cid=D094A2U16DS)

<div><a href="https://cursor.com/agents/bc-05dfd707-f5b0-5c35-a7d5-4af3728963d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05dfd707-f5b0-5c35-a7d5-4af3728963d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

