### PR TITLE
[DX-1319] Add type-surface breaking-change check

### DIFF
--- a/.github/workflows/type-surface.yml
+++ b/.github/workflows/type-surface.yml
@@ -53,8 +53,8 @@ jobs:
           yarn build
 
       - name: Check type surface
-        # TODO: switch to @main once elevenlabs/elevenlabs-dx#2566 merges.
-        uses: elevenlabs/elevenlabs-dx/.github/actions/dts-breaking-changes@kh/dx-1319-dts-breaking-changes
+        # TODO: switch to @main once elevenlabs/packages#917 merges.
+        uses: elevenlabs/packages/.github/actions/dts-breaking-changes@kh/dx-1319-dts-breaking-changes
         with:
           old-dir: ${{ runner.temp }}/base/dist
           new-dir: dist

--- a/.github/workflows/type-surface.yml
+++ b/.github/workflows/type-surface.yml
@@ -1,0 +1,63 @@
+name: type surface
+
+# Warns when a PR introduces a breaking change to the public type surface,
+# comparing the built dist/index.d.ts against the merge-base. A consumer-breaking
+# change fails the check; add the `breaking` label to acknowledge (turns it into
+# a warning). labeled/unlabeled re-run so toggling the label clears/raises it.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: type-surface-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  breaking-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout head
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Build head
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+
+      - name: Build merge-base in a worktree
+        id: base
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
+          BASE_SHA="$(git merge-base FETCH_HEAD HEAD)"
+          echo "Merge-base: $BASE_SHA"
+          echo "sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+
+          # Same build, run against the base checkout — no drift between the two.
+          git worktree add --detach "$RUNNER_TEMP/base" "$BASE_SHA"
+          cd "$RUNNER_TEMP/base"
+          yarn install --frozen-lockfile
+          yarn build
+
+      - name: Check type surface
+        # TODO: switch to @main once elevenlabs/elevenlabs-dx#2566 merges.
+        uses: elevenlabs/elevenlabs-dx/.github/actions/dts-breaking-changes@kh/dx-1319-dts-breaking-changes
+        with:
+          old-dir: ${{ runner.temp }}/base/dist
+          new-dir: dist
+          entry: index.d.ts
+          base-sha: ${{ steps.base.outputs.sha }}
+          title: "@elevenlabs/elevenlabs-js"

--- a/.github/workflows/type-surface.yml
+++ b/.github/workflows/type-surface.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: lts/Krypton
 
       - name: Build head
         run: |


### PR DESCRIPTION
## What

Adds a `pull_request` workflow that warns when a PR introduces a breaking change to the public type surface. It builds the head's `dist/index.d.ts` and the merge-base's, then runs the [`dts-breaking-changes` composite action](https://github.com/elevenlabs/elevenlabs-dx/tree/kh/dx-1319-dts-breaking-changes/.github/actions/dts-breaking-changes) from elevenlabs-dx to compare them.

This is the pilot for DX-1319 (single package, no PR CI here today).

## How it works

- Builds head with the repo's own `yarn build` (plain `tsc`), then builds the **merge-base** in a `git worktree` so the exact same build runs against both checkouts (no drift). The comment states the base SHA used.
- A **consumer-breaking** change (removed export, narrowed output, added required *input* field, dropped overload) fails the check. Variance-aware: adding a required field to an *output* type is not flagged.
- The **`breaking` label** is the escape hatch: it downgrades a failure to a warning. `labeled`/`unlabeled` triggers re-run so toggling the label clears or raises the check.

## Dependency

- The action is referenced on its feature branch (`@kh/dx-1319-dts-breaking-changes`) so this PR can run end-to-end now. It switches to `@main` once elevenlabs/elevenlabs-dx#2566 merges.

## Test plan

- [ ] First run on this PR (which changes no `.d.ts`) reports no type-surface changes and the check passes
- [ ] A follow-up experiment that removes an export or adds a required input field turns the check red
- [ ] Adding the `breaking` label to that experiment turns the check back green (warning)

## Notes

- Two `yarn install`/`yarn build` runs (head + base) is the deliberately-simple baseline. The DX-1319 progressive-hardening step (artifact-based baseline keyed by SHA) is a follow-up and needs no engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)