### PR TITLE
Add fileIds to sendMultimodalMessage

### DIFF
--- a/src/api/resources/conversationalAi/conversation/Conversation.ts
+++ b/src/api/resources/conversationalAi/conversation/Conversation.ts
@@ -172,26 +172,34 @@ export class Conversation extends EventEmitter {
     }
 
     /**
-     * Send a multimodal message combining text and a file reference to the agent.
+     * Send a multimodal message combining text and file references to the agent.
      *
-     * At least one of `text` or `fileId` must be provided.
+     * At least one of `text`, `fileId`, or `fileIds` must be provided.
      *
      * @param options.text Optional text message to include
-     * @param options.fileId Optional ElevenLabs file ID to include
+     * @param options.fileId @deprecated Use `fileIds`.
+     * @param options.fileIds Optional ElevenLabs file IDs to include
      */
-    public sendMultimodalMessage(options: { text?: string; fileId?: string }): void {
+    public sendMultimodalMessage(options: {
+        text?: string;
+        /** @deprecated Use `fileIds`. */
+        fileId?: string;
+        fileIds?: string[];
+    }): void {
         if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
             throw new Error("Session not started or websocket not connected");
         }
 
-        if (!options.text && !options.fileId) {
-            throw new Error("At least one of text or fileId must be provided");
+        const fileIds = options.fileIds?.length ? options.fileIds : options.fileId ? [options.fileId] : [];
+        if (!options.text && fileIds.length === 0) {
+            throw new Error("At least one of text, fileId, or fileIds must be provided");
         }
 
+        const files = fileIds.map((file_id) => ({ type: "file_input" as const, file_id }));
         const event: MultimodalMessageClientToOrchestratorEvent = {
             type: ClientToOrchestratorEvent.MULTIMODAL_MESSAGE,
             ...(options.text && { text: { type: ClientToOrchestratorEvent.USER_MESSAGE, text: options.text } }),
-            ...(options.fileId && { file: { type: "file_input", file_id: options.fileId } }),
+            ...(files.length && { file: files[0], files }),
         };
 
         this.ws.send(JSON.stringify(event));

--- a/src/api/resources/conversationalAi/conversation/__tests__/Conversation.test.ts
+++ b/src/api/resources/conversationalAi/conversation/__tests__/Conversation.test.ts
@@ -214,6 +214,7 @@ describe("Conversation", () => {
                     type: "multimodal_message",
                     text: { type: "user_message", text: "What is in this file?" },
                     file: { type: "file_input", file_id: "file_abc123" },
+                    files: [{ type: "file_input", file_id: "file_abc123" }],
                 }),
             );
         });
@@ -236,13 +237,29 @@ describe("Conversation", () => {
                 JSON.stringify({
                     type: "multimodal_message",
                     file: { type: "file_input", file_id: "file_abc123" },
+                    files: [{ type: "file_input", file_id: "file_abc123" }],
                 }),
             );
         });
 
-        it("should throw error when sending multimodal message without text or fileId", () => {
+        it("should send multimodal message with fileIds and dual-send file", () => {
+            conversation.sendMultimodalMessage({ fileIds: ["file_a", "file_b"] });
+
+            expect(mockWebSocket.send).toHaveBeenCalledWith(
+                JSON.stringify({
+                    type: "multimodal_message",
+                    file: { type: "file_input", file_id: "file_a" },
+                    files: [
+                        { type: "file_input", file_id: "file_a" },
+                        { type: "file_input", file_id: "file_b" },
+                    ],
+                }),
+            );
+        });
+
+        it("should throw error when sending multimodal message without text, fileId, or fileIds", () => {
             expect(() => conversation.sendMultimodalMessage({})).toThrow(
-                "At least one of text or fileId must be provided",
+                "At least one of text, fileId, or fileIds must be provided",
             );
         });
 

--- a/src/api/resources/conversationalAi/conversation/events.ts
+++ b/src/api/resources/conversationalAi/conversation/events.ts
@@ -99,6 +99,7 @@ export interface MultimodalMessageClientToOrchestratorEvent extends BaseClientTo
     type: ClientToOrchestratorEvent.MULTIMODAL_MESSAGE;
     text?: UserMessageClientToOrchestratorEvent;
     file?: MultimodalMessageFile;
+    files?: MultimodalMessageFile[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `fileIds` beside the existing `fileId` on `sendMultimodalMessage` (plural wins).
- Dual-send `file` + `files` on the wire so older backends still receive the first attachment.
- Mark `fileId` as deprecated. Do not delete it.

Written by Cursor Grok 4.6, using Cursor

## Test plan
- [x] Existing multimodal tests updated to expect both `file` and `files`
- [x] New plural `fileIds` test
- [ ] CI on this PR
- [ ] Confirm an old backend still accepts a payload with both `file` and `files`