### PR TITLE
feat: widen speech-to-text model_id from enum to string

### DIFF
--- a/src/api/resources/speechToText/types/SpeechToTextConvertRequestModelId.ts
+++ b/src/api/resources/speechToText/types/SpeechToTextConvertRequestModelId.ts
@@ -6,4 +6,5 @@ export const SpeechToTextConvertRequestModelId = {
     ScribeV1: "scribe_v1",
 } as const;
 export type SpeechToTextConvertRequestModelId =
-    (typeof SpeechToTextConvertRequestModelId)[keyof typeof SpeechToTextConvertRequestModelId];
+    | (typeof SpeechToTextConvertRequestModelId)[keyof typeof SpeechToTextConvertRequestModelId]
+    | (string & {});

--- a/src/serialization/resources/speechToText/types/SpeechToTextConvertRequestModelId.ts
+++ b/src/serialization/resources/speechToText/types/SpeechToTextConvertRequestModelId.ts
@@ -7,8 +7,8 @@ import type * as serializers from "../../../index";
 export const SpeechToTextConvertRequestModelId: core.serialization.Schema<
     serializers.SpeechToTextConvertRequestModelId.Raw,
     ElevenLabs.SpeechToTextConvertRequestModelId
-> = core.serialization.enum_(["scribe_v2", "scribe_v1"]);
+> = core.serialization.string();
 
 export declare namespace SpeechToTextConvertRequestModelId {
-    export type Raw = "scribe_v2" | "scribe_v1";
+    export type Raw = string;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `model_id` field in the speech-to-text `convert` method was validated against a strict enum (`scribe_v2`, `scribe_v1`). This caused a runtime `JsonError: Expected enum. Received "scribe_v2_5"` when users tried to use hidden/preview models.

## Changes

- **`src/api/resources/speechToText/types/SpeechToTextConvertRequestModelId.ts`**: Widened the TypeScript type to `"scribe_v2" | "scribe_v1" | (string & {})`, preserving autocomplete for known values while accepting any string.
- **`src/serialization/resources/speechToText/types/SpeechToTextConvertRequestModelId.ts`**: Changed the runtime serializer from `core.serialization.enum_(["scribe_v2", "scribe_v1"])` to `core.serialization.string()`, removing the runtime enum validation.

## Motivation

A customer needed to use the `scribe_v2_5` hidden model via the JS SDK. The REST API accepted it fine, but the SDK's enum validation rejected it with a `JsonError`. As Paul noted, making `model_id` a string instead of a `oneOf` is the correct fix — the API server will error on truly invalid model names anyway.

The named constants (`SpeechToTextConvertRequestModelId.ScribeV2`, etc.) are preserved for backward compatibility.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://eleven-labs-workspace.slack.com/archives/C08D7SK6AMT/p1781515906665369?thread_ts=1781515906.665369&cid=C08D7SK6AMT)

<div><a href="https://cursor.com/agents/bc-93ef178e-8619-54f7-94cc-c64f5b9d1281?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93ef178e-8619-54f7-94cc-c64f5b9d1281&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

